### PR TITLE
Adding mqtt_v2 plugin

### DIFF
--- a/rpi_power_monitor/plugins/mqtt_v2/README.md
+++ b/rpi_power_monitor/plugins/mqtt_v2/README.md
@@ -40,3 +40,4 @@ Alter max_publish_seconds to define how often values are republished regardless 
 ## Support
 Please post any issues or questions in the pull request thread located here:
 
+https://github.com/David00/rpi-power-monitor/pull/124

--- a/rpi_power_monitor/plugins/mqtt_v2/README.md
+++ b/rpi_power_monitor/plugins/mqtt_v2/README.md
@@ -36,6 +36,36 @@ This plugin will send all measurements for all channels to the host specified ab
 Alter power_change, voltage_change, current_change, pf_change to define how much variation in the values will trigger a publish
 Alter max_publish_seconds to define how often values are republished regardless of variation
 
+## Configuration options
+
+    enabled
+
+Needs to be set to true to enable the plugin.
+
+    username
+    password
+
+Specify the required username and password for MQTT. Leave "" if you are not using MQTT authentification.
+
+    prefix
+
+Specify the prefix of the mqtt topic used to publish the values.
+
+    power_change
+    voltage_change
+    current_change
+    pf_change
+
+Define these values to determine the required variation in power, voltage, current or pf that will force an MQTT publish of the new value if detected over a period of less than the configured max_publish_seconds.
+For example, with a configuration of voltage_change = 3, if the voltage is stable at 122.00 volt and it drops to 118.00 volt over a period of time that is less than the configured max_publish_seconds, the 118.00 volt value will be published to MQTT immediately and as soon as detected as it is a delta of 4 volt which is greater than the configured 3 volt. The same would occur if 118.00 volt is measured and an increase to 122.00 volt occurs over a time period of less than max_publish_seconds.
+
+    max_publish_seconds
+
+Define this value to force a publish of the refreshed and most up to date values of all measurements regardless of they changed of not.
+
+    refresh_rate
+
+How often this plugin will read current values from the samples provided by rpi-power-monitor.
 
 ## Support
 Please post any issues or questions in the pull request thread located here:

--- a/rpi_power_monitor/plugins/mqtt_v2/README.md
+++ b/rpi_power_monitor/plugins/mqtt_v2/README.md
@@ -1,0 +1,42 @@
+# MQTT Documentation
+
+#### Author: jplord, based on jmadden91 v1 implementation
+
+## Purpose
+
+The MQTT plugin allows you to export power monitor data to a MQTT-capable system. 
+
+## Setup & Usage
+You'll need to install the paho mqtt v2 client to use this plugin:
+
+    pip install paho-mqtt>=2
+
+
+The following configuration block needs to be added to the power monitor's `config.toml` file
+
+```toml
+
+[plugins.mqtt_v2]
+    enabled = true
+    host = "xxx.xxx.xxx.xxx"
+    # Leave Username and Password "" if you are not using authentification
+    username = ""
+    password = ""
+    prefix = "powermon"
+    power_change = 5
+    voltage_change = 3
+    current_change = 1
+    pf_change = 0.05
+    refresh_rate = 5 # Refresh rate in seconds
+    max_publish_seconds = 600
+
+```
+
+This plugin will send all measurements for all channels to the host specified above.
+Alter power_change, voltage_change, current_change, pf_change to define how much variation in the values will trigger a publish
+Alter max_publish_seconds to define how often values are republished regardless of variation
+
+
+## Support
+Please post any issues or questions in the pull request thread located here:
+

--- a/rpi_power_monitor/plugins/mqtt_v2/README.md
+++ b/rpi_power_monitor/plugins/mqtt_v2/README.md
@@ -61,7 +61,7 @@ For example, with a configuration of voltage_change = 3, if the voltage is stabl
 
     max_publish_seconds
 
-Define this value to force a publish of the refreshed and most up to date values of all measurements regardless of they changed of not.
+Define this value to force a publish of the refreshed and most up to date values of all measurements regardless of if they changed of not.
 
     refresh_rate
 

--- a/rpi_power_monitor/plugins/mqtt_v2/mqtt_v2.py
+++ b/rpi_power_monitor/plugins/mqtt_v2/mqtt_v2.py
@@ -1,0 +1,169 @@
+import paho.mqtt.client as mqtt
+from .. import sleep_for
+from time import time
+
+def start_plugin(data, stop_flag, config, logger, *args, **kwargs):
+
+    def on_connect(client, userdata, flags, reason_code, properties):
+        if reason_code == 0:
+            logger.debug("Connected to MQTT broker")
+            client.publish(prefix + "/status", "online")
+        if reason_code > 0:
+            logger.error(f"Failed to connect to MQTT broker with error code: {rc}")
+
+    logger.info("Starting MQTT_v2 Plugin")
+
+    # MQTT Setup
+    broker = config.get('host')
+    username = config.get('username')
+    password = config.get('password')
+    prefix = config.get('prefix')
+    refresh_rate = config.get('refresh_rate')
+    minchangedict = {}
+    minchangedict["power"] = config.get('power_change')
+    minchangedict["voltage"] = config.get('voltage_change')
+    minchangedict["pf"] = config.get('pf_change')
+    minchangedict["current"] = config.get('current_change')
+    max_publish_seconds = config.get('max_publish_seconds')
+    lastpublishval = {}
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.username_pw_set(username, password)
+
+    # Set Last Will and Testament (LWT)
+    will_topic = f"{prefix}/status"
+    will_payload = "offline"
+    will_qos = 0  # Quality of Service Level (0, 1, or 2)
+    will_retain = False  # Retain message or not
+
+    client.will_set(will_topic, payload=will_payload, qos=will_qos, retain=will_retain)
+
+    client.on_connect = on_connect
+
+    client.connect(broker, 1883, 60)
+    client.loop_start()
+    sleep_for(2, stop_flag)
+    client.publish(prefix + "/status", "online")
+
+    while not stop_flag.is_set():
+
+
+        for channel, channel_data in data.get('cts', {}).items():
+            for key, value in channel_data.items():
+                if value is not None:
+                    topic = f"{prefix}/ct{channel}/{key}"
+                    payload = str(round(value, 2))
+                    try:
+                        testvar = lastpublishval[channel]
+                    except KeyError:
+                        lastpublishval[channel] = {}
+                    try:
+                        testvar = lastpublishval[channel][key]
+                    except KeyError:
+                        lastpublishval[channel][key] = 0
+                        lastpublishval[channel][key + "-time"] = 0
+                    try:
+                        testvar = minchangedict[key]
+                    except KeyError:
+                         minchangedict[key] = 0
+                    if abs(value - lastpublishval[channel][key]) >= minchangedict[key] or time() - lastpublishval[channel][key + "-time"] >= max_publish_seconds:
+                        client.publish(topic, payload)
+                        lastpublishval[channel][key] = value
+                        lastpublishval[channel][key + "-time"] = time()
+
+        for key, value in data.get('production', {}).items():
+            if value is not None:
+                topic = f"{prefix}/production/{key}"
+                payload = str(round(value, 2))
+                try:
+                    testvar = lastpublishval["production"]
+                except KeyError:
+                    lastpublishval["production"] = {}
+                try:
+                    testvar = lastpublishval["production"][key]
+                except KeyError:
+                    lastpublishval["production"][key] = 0
+                    lastpublishval["production"][key + "-time"] = 0
+                try:
+                    testvar = minchangedict[key]
+                except KeyError:
+                     minchangedict[key] = 0
+                if abs(value - lastpublishval["production"][key]) >= minchangedict[key] or time() - lastpublishval["production"][key + "-time"] >= max_publish_seconds:
+                    client.publish(topic, payload)
+                    lastpublishval["production"][key] = value
+                    lastpublishval["production"][key + "-time"] = time()
+
+        for key, value in data.get('home-consumption', {}).items():
+            if value is not None:
+                topic = f"{prefix}/home-consumption/{key}"
+                payload = str(round(value, 2))
+                try:
+                    testvar = lastpublishval["home-consumption"]
+                except KeyError:
+                    lastpublishval["home-consumption"] = {}
+                try:
+                    testvar = lastpublishval["home-consumption"][key]
+                except KeyError:
+                    lastpublishval["home-consumption"][key] = 0
+                    lastpublishval["home-consumption"][key + "-time"] = 0
+                try:
+                    testvar = minchangedict[key]
+                except KeyError:
+                     minchangedict[key] = 0
+                if abs(value - lastpublishval["home-consumption"][key]) >= minchangedict[key] or time() - lastpublishval["home-consumption"][key + "-time"] >= max_publish_seconds:
+                    client.publish(topic, payload)
+                    lastpublishval["home-consumption"][key] = value
+                    lastpublishval["home-consumption"][key + "-time"] = time()
+
+        for key, value in data.get('net', {}).items():
+            if value is not None:
+                topic = f"{prefix}/net/{key}"
+                payload = str(round(value, 2))
+                try:
+                    testvar = lastpublishval["net"]
+                except KeyError:
+                    lastpublishval["net"] = {}
+                try:
+                    testvar = lastpublishval["net"][key]
+                except KeyError:
+                    lastpublishval["net"][key] = 0
+                    lastpublishval["net"][key + "-time"] = 0
+                try:
+                    testvar = minchangedict[key]
+                except KeyError:
+                     minchangedict[key] = 0
+                if abs(value - lastpublishval["net"][key]) >= minchangedict[key] or time() - lastpublishval["net"][key + "-time"] >= max_publish_seconds:
+                    client.publish(topic, payload)
+                    lastpublishval["net"][key] = value
+                    lastpublishval["net"][key + "-time"] = time()
+
+        topic = f"{prefix}/voltage"
+        voltage = data.get('voltage')
+        if voltage is not None:
+            payload = str(round(voltage, 2))
+            try:
+                testvar = lastpublishval["voltage"]
+            except KeyError:
+                lastpublishval["voltage"] = 0
+                lastpublishval["voltage-time"] = 0
+            try:
+                testvar = minchangedict["voltage"]
+            except KeyError:
+                 minchangedict["voltage"] = 0
+            if abs(voltage - lastpublishval["voltage"]) >= minchangedict["voltage"] or time() - lastpublishval["voltage-time"] >= max_publish_seconds:
+                client.publish(topic, payload)
+                lastpublishval["voltage"] = voltage
+                lastpublishval["voltage-time"] = time()
+
+        sleep_for(refresh_rate, stop_flag)
+
+
+    stop_plugin(client)
+    return
+
+
+def stop_plugin(client):
+    client.disconnect()
+    client.loop_stop()
+
+
+    return


### PR DESCRIPTION
Adding mqtt_v2 plugin. Creating a new plugin vs modifying since this one only supports paho-mqtt v2.
Added features for avoiding republishing the same values if they didn't change. See readme.md